### PR TITLE
Remove package.xml from manifest to avoid md5 checksum errors when installing via pecl

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -58,7 +58,6 @@ Note: This extension will work with PHP 8.0-8.1, but will segfault when you over
    <dir name="output">
     <file name=".gitkeep" role="test"/>
    </dir>
-   <file name="package.xml" role="doc"/>
    <file name="README.md" role="doc"/>
    <dir name="tests">
     <file name="Arithemetic.phpt" role="test"/>


### PR DESCRIPTION
This PR fixes the following error:

```
$ pecl install operator-beta
ERROR: bad md5sum for file /usr/local/lib/php/doc/operator/package.xml
```
