### PR TITLE
Fix checking pecl installation in a temp dir

### DIFF
--- a/.github/workflows/build-pecl.yml
+++ b/.github/workflows/build-pecl.yml
@@ -43,12 +43,15 @@ jobs:
         uses: actions/checkout@v4
       -
         name: Create temporary directory
-        run: cd "$(mktemp -d)"
+        id: tempdir
+        run: echo "path=$(mktemp -d)" >>$GITHUB_OUTPUT
       -
         name: Create package
+        working-directory: ${{ steps.tempdir.outputs.path }}
         run: pecl package "$GITHUB_WORKSPACE/package.xml"
       -
         name: Compile package
+        working-directory: ${{ steps.tempdir.outputs.path }}
         run: printf '' | MAKE="make -j$(nproc)" pecl install operator-*.tgz
       -
         name: Enable extension


### PR DESCRIPTION
This PR fixes a mistake I did in #1 (the current working directory isn't maintained across steps)